### PR TITLE
updating colstart kwarg

### DIFF
--- a/examples/ssd1675_2.13_monochrome.py
+++ b/examples/ssd1675_2.13_monochrome.py
@@ -28,7 +28,7 @@ display_bus = displayio.FourWire(
 time.sleep(1)
 
 display = adafruit_ssd1675.SSD1675(
-    display_bus, width=250, height=122, rotation=270, busy_pin=epd_busy
+    display_bus, colstart=8, width=250, height=122, rotation=270, busy_pin=epd_busy
 )
 
 g = displayio.Group()


### PR DESCRIPTION
Tested on

`Adafruit CircuitPython 8.0.0 on 2023-02-06; Adafruit Feather RP2040 with rp2040` 
When adding the colstart=8. Image is correctly displayed

![image](https://user-images.githubusercontent.com/34255413/221066834-ff2c18dc-87f7-459a-928a-6f41c14657e5.png)


