### PR TITLE
reverting_example

### DIFF
--- a/examples/ssd1675_2.13_monochrome.py
+++ b/examples/ssd1675_2.13_monochrome.py
@@ -28,7 +28,7 @@ display_bus = displayio.FourWire(
 time.sleep(1)
 
 display = adafruit_ssd1675.SSD1675(
-    display_bus, colstart=8, width=250, height=122, rotation=270, busy_pin=epd_busy
+    display_bus, width=250, height=122, rotation=270, busy_pin=epd_busy
 )
 
 g = displayio.Group()


### PR DESCRIPTION
@tannewt 
Reverting example for colstart

for the SSD1680 example was merged here: https://github.com/adafruit/Adafruit_CircuitPython_SSD1680/pull/12

Thanks!